### PR TITLE
Cube Label State Update

### DIFF
--- a/isis/src/apollo/apps/apollopanstitcher/apollopanstitcher.cpp
+++ b/isis/src/apollo/apps/apollopanstitcher/apollopanstitcher.cpp
@@ -715,11 +715,11 @@ namespace Isis {
     att.setFileFormat( panC[0]->format() );
     att.setByteOrder(  panC[0]->byteOrder() );
     att.setPixelType(  panC[0]->pixelType() );
-    if (panC[0]->labelsAttached()) {
-      att.setLabelAttachment(AttachedLabel);
+    if (panC[0]->labelsAttached() == Cube::AttachedLabel) {
+      att.setLabelAttachment(Cube::AttachedLabel);
     }
     else {
-      att.setLabelAttachment(DetachedLabel);
+      att.setLabelAttachment(Cube::DetachedLabel);
     }
 
     //define an output cube

--- a/isis/src/base/apps/noproj/noproj.cpp
+++ b/isis/src/base/apps/noproj/noproj.cpp
@@ -189,7 +189,7 @@ namespace Isis {
     CubeAttributeOutput cao;
 
     // Can we do a regular label? Didn't work on 12-15-2006
-    cao.setLabelAttachment(Isis::DetachedLabel);
+    cao.setLabelAttachment(Cube::DetachedLabel);
     FileName matchCubeFile = FileName::createTempFile("$Temporary/match.cub");
     QString matchCubeFileNoExt = matchCubeFile.path() + "/" + matchCubeFile.baseName();
 

--- a/isis/src/base/objs/Cube/Cube.cpp
+++ b/isis/src/base/objs/Cube/Cube.cpp
@@ -500,7 +500,7 @@ namespace Isis {
         m_labelFile = new QFile(m_labelFileName->expanded());
       }
       else {
-        QString msg = "Label type [" + LabelAttachmentName(labelsAttached()) + "] not handled";
+        QString msg = "Label type [" + LabelAttachmentName(labelsAttached()) + "] not supported";
         throw IException(IException::Programmer, msg, _FILEINFO_);
       }
       core.addGroup(dims);
@@ -510,14 +510,13 @@ namespace Isis {
       cubFile = cubFile.addExtension("ecub");
 
       core += PvlKeyword("^DnFile", m_dataFileName->original());
-//       m_dataFileName = new FileName(cubFile);
       m_dataFile = new QFile(realDataFileName().expanded());
 
       m_labelFileName = new FileName(cubFile);
       m_labelFile = new QFile(cubFile.expanded());
     }
     else {
-      QString msg = "Label type [" + LabelAttachmentName(labelsAttached()) + "] not handled";
+      QString msg = "Label type [" + LabelAttachmentName(labelsAttached()) + "] not supported";
       throw IException(IException::Programmer, msg, _FILEINFO_);
     }
 

--- a/isis/src/base/objs/Cube/Cube.h
+++ b/isis/src/base/objs/Cube/Cube.h
@@ -234,6 +234,27 @@ namespace Isis {
         Tiff
       };
 
+      /**
+       * @brief Input cube label type tracker
+       *
+       * This enumeration and its functions are for the label
+       * type of an input cube. The enum defines the type of labels (i.e.,
+       * Both the label and cube are in the same file and the label is in a
+       * separate file from the cube.
+       */
+      enum LabelAttachment {
+        AttachedLabel,  //!< The input label is embedded in the image file
+        DetachedLabel,  //!< The input label is in a separate data file from the image
+        /**
+         * The label is pointing to an external DN file - the label is also external to the data.
+         *
+         * This format implies that the output is a cube that contains everything except DN data
+         *   (more similar to attached than detached).
+         */
+        ExternalLabel,
+        GdalLabel
+      };
+
       void fromIsd(const FileName &fileName, Pvl &label, nlohmann::json &isd, QString access);
       void fromIsd(const FileName &fileName, FileName &labelFile, FileName &isdFile, QString access);
 
@@ -243,8 +264,8 @@ namespace Isis {
       bool isProjected() const;
       bool isReadOnly() const;
       bool isReadWrite() const;
-      bool labelsAttached() const;
-      bool labelsExternal() const;
+      LabelAttachment labelsAttached() const;
+      // bool labelsExternal() const;
 
       void attachSpiceFromIsd(nlohmann::json Isd);
 
@@ -280,8 +301,8 @@ namespace Isis {
       void setDimensions(int ns, int nl, int nb);
       void setExternalDnData(FileName cubeFileWithDnData);
       void setFormat(Format format);
-      void setLabelsAttached(bool attached);
-      void setLabelsExternal(bool external);
+      void setLabelsAttached(LabelAttachment attached);
+      // void setLabelsExternal(bool external);
       void setLabelSize(int labelBytes);
       void setPixelType(PixelType pixelType);
       void setVirtualBands(const QList<QString> &vbands);
@@ -315,7 +336,6 @@ namespace Isis {
       Statistics *statistics(const int &band, const double &validMin,
                              const double &validMax,
                              QString msg = "Gathering statistics");
-      bool storesDnData() const;
 
       void addCachingAlgorithm(CubeCachingAlgorithm *);
       void clearIoCache();
@@ -415,7 +435,7 @@ namespace Isis {
       FileName *m_formatTemplateFile;
 
       //! True if labels are attached
-      bool m_attached;
+      LabelAttachment m_attached;
 
       //! True if labels are external
       bool m_external;

--- a/isis/src/base/objs/Cube/Cube.h
+++ b/isis/src/base/objs/Cube/Cube.h
@@ -265,7 +265,6 @@ namespace Isis {
       bool isReadOnly() const;
       bool isReadWrite() const;
       LabelAttachment labelsAttached() const;
-      // bool labelsExternal() const;
 
       void attachSpiceFromIsd(nlohmann::json Isd);
 

--- a/isis/src/base/objs/Cube/unitTest.cpp
+++ b/isis/src/base/objs/Cube/unitTest.cpp
@@ -88,7 +88,7 @@ int main(int argc, char *argv[]) {
     cerr << "Creating 8-bit cube ... " << endl;
     Cube out2;
     out2.setDimensions(150, 200, 1);
-    out2.setLabelsAttached(false);
+    out2.setLabelsAttached(Cube::DetachedLabel);
     out2.setBaseMultiplier(200.0, -1.0);
 //  out2.SetByteOrder(Msb);
     out2.setByteOrder(ISIS_LITTLE_ENDIAN ? Msb : Lsb);

--- a/isis/src/base/objs/CubeAttribute/CubeAttribute.cpp
+++ b/isis/src/base/objs/CubeAttribute/CubeAttribute.cpp
@@ -392,22 +392,22 @@ namespace Isis {
   }
 
 
-  void CubeAttributeOutput::setLabelAttachment(LabelAttachment attachment) {
+  void CubeAttributeOutput::setLabelAttachment(Cube::LabelAttachment attachment) {
     setAttribute(LabelAttachmentName(attachment), &CubeAttributeOutput::isLabelAttachment);
   }
 
 
-  LabelAttachment CubeAttributeOutput::labelAttachment() const {
-    LabelAttachment result = AttachedLabel;
+  Cube::LabelAttachment CubeAttributeOutput::labelAttachment() const {
+    Cube::LabelAttachment result = Cube::AttachedLabel;
 
     QStringList labelAttachmentAtts = attributeList(&CubeAttributeOutput::isLabelAttachment);
     if (!labelAttachmentAtts.isEmpty()) {
       QString labelAttachmentAtt = labelAttachmentAtts.last();
 
       if (labelAttachmentAtt == "DETACHED")
-        result = DetachedLabel;
+        result = Cube::DetachedLabel;
       else if (labelAttachmentAtt == "EXTERNAL")
-        result = ExternalLabel;
+        result = Cube::ExternalLabel;
     }
 
     return result;
@@ -420,12 +420,12 @@ namespace Isis {
 
 
   bool CubeAttributeOutput::isFileFormat(QString attribute) const {
-    return QRegExp("(BANDSEQUENTIAL|BSQ|TILE)").exactMatch(attribute);
+    return QRegExp("(BANDSEQUENTIAL|BSQ|TILE|TIFF)").exactMatch(attribute);
   }
 
 
   bool CubeAttributeOutput::isLabelAttachment(QString attribute) const {
-    return QRegExp("(ATTACHED|DETACHED|EXTERNAL)").exactMatch(attribute);
+    return QRegExp("(ATTACHED|DETACHED|EXTERNAL|GDAL)").exactMatch(attribute);
   }
 
 

--- a/isis/src/base/objs/CubeAttribute/CubeAttribute.h
+++ b/isis/src/base/objs/CubeAttribute/CubeAttribute.h
@@ -21,27 +21,6 @@ find files of those names at the top level of this repository. **/
 
 namespace Isis {
   /**
-   * @brief Input cube label type tracker
-   *
-   * This enumeration and its functions are for the label
-   * type of an input cube. The enum defines the type of labels (i.e.,
-   * Both the label and cube are in the same file and the label is in a
-   * separate file from the cube.
-   */
-  enum LabelAttachment {
-    AttachedLabel,  //!< The input label is embedded in the image file
-    DetachedLabel,  //!< The input label is in a separate data file from the image
-    /**
-     * The label is pointing to an external DN file - the label is also external to the data.
-     *
-     * This format implies that the output is a cube that contains everything except DN data
-     *   (more similar to attached than detached).
-     */
-    ExternalLabel
-  };
-
-
-  /**
    * Return the string representation of the contents of a
    * variable of type LabelAttachment
    *
@@ -49,10 +28,11 @@ namespace Isis {
    *
    * @return A string representation of the parameter
    */
-  inline QString LabelAttachmentName(LabelAttachment labelType) {
-    if(labelType == AttachedLabel) return "Attached";
-    if(labelType == DetachedLabel) return "Detached";
-    if(labelType == ExternalLabel) return "External";
+  inline QString LabelAttachmentName(Cube::LabelAttachment labelType) {
+    if(labelType == Cube::AttachedLabel) return "Attached";
+    if(labelType == Cube::DetachedLabel) return "Detached";
+    if(labelType == Cube::ExternalLabel) return "External";
+    if(labelType == Cube::GdalLabel) return "Gdal";
 
     QString msg = "Invalid label attachment type [" + QString::number(labelType) + "]";
     throw IException(IException::Programmer, msg, _FILEINFO_);
@@ -67,17 +47,16 @@ namespace Isis {
    *
    * @return The RangeType enum corresponding to the string parameter
    */
-  inline LabelAttachment LabelAttachmentEnumeration(const QString &labelType) {
+  inline Cube::LabelAttachment LabelAttachmentEnumeration(const QString &labelType) {
     QString temp = labelType.toUpper();
-    if(temp == "ATTACHED") return AttachedLabel;
-    if(temp == "DETACHED") return DetachedLabel;
-    if(temp == "EXTERNAL") return ExternalLabel;
+    if(temp == "ATTACHED") return Cube::AttachedLabel;
+    if(temp == "DETACHED") return Cube::DetachedLabel;
+    if(temp == "EXTERNAL") return Cube::ExternalLabel;
+    if(temp == "GDAL") return Cube::GdalLabel;
 
     QString msg = "Invalid label attachment type string [" + labelType + "]";
     throw IException(IException::Unknown, msg, _FILEINFO_);
   }
-
-
 
   /**
    * @brief Parent class for CubeAttributeInput and CubeAttributeOutput.
@@ -539,9 +518,9 @@ namespace Isis {
       void setPixelType(PixelType type);
 
       //! Set the label attachment type to the parameter value
-      void setLabelAttachment(LabelAttachment attachment);
+      void setLabelAttachment(Cube::LabelAttachment attachment);
 
-      LabelAttachment labelAttachment() const;
+      Cube::LabelAttachment labelAttachment() const;
 
       using CubeAttribute<CubeAttributeOutput>::toString;
 

--- a/isis/src/base/objs/CubeAttribute/unitTest.cpp
+++ b/isis/src/base/objs/CubeAttribute/unitTest.cpp
@@ -205,10 +205,10 @@ int main(int argc, char *argv[]) {
     att.setPixelType(Real);
     cout << att.toString() << endl;
 
-    att.setLabelAttachment(DetachedLabel);
+    att.setLabelAttachment(Cube::DetachedLabel);
     cout << att.toString() << endl;
 
-    att.setLabelAttachment(ExternalLabel);
+    att.setLabelAttachment(Cube::ExternalLabel);
     cout << att.toString() << endl;
   }
   catch (IException &e) {
@@ -300,8 +300,8 @@ void reportOutput(const CubeAttributeOutput &att, QString orderHint) {
   }
 
   cout << "Label attachment     = ";
-  if(att.labelAttachment() == AttachedLabel)  cout << LabelAttachmentName(AttachedLabel) << endl;
-  if(att.labelAttachment() == DetachedLabel) cout << LabelAttachmentName(DetachedLabel) << endl;
+  if(att.labelAttachment() == Cube::AttachedLabel)  cout << LabelAttachmentName(Cube::AttachedLabel) << endl;
+  if(att.labelAttachment() == Cube::DetachedLabel) cout << LabelAttachmentName(Cube::DetachedLabel) << endl;
 
 #if 0
   fstream stream("CubeAttribute.truth", ios::in | ios::out);

--- a/isis/src/base/objs/Gui/GuiOutputAttribute.cpp
+++ b/isis/src/base/objs/Gui/GuiOutputAttribute.cpp
@@ -244,7 +244,7 @@ namespace Isis {
       p_msb->setChecked(true);
     }
 
-    if(att.labelAttachment() == AttachedLabel) {
+    if(att.labelAttachment() == Cube::AttachedLabel) {
       p_attached->setChecked(true);
     }
     else {

--- a/isis/src/base/objs/Process/Process.cpp
+++ b/isis/src/base/objs/Process/Process.cpp
@@ -330,8 +330,8 @@ Isis::Cube *Process::SetOutputCubeStretch(const QString &parameter, const int ns
       cube->setDimensions(ns, nl, nb);
       cube->setByteOrder(att.byteOrder());
       cube->setFormat(att.fileFormat());
-      cube->setLabelsAttached(!(att.labelAttachment() == DetachedLabel));
-      cube->setLabelsExternal(att.labelAttachment() == ExternalLabel);
+      cube->setLabelsAttached(att.labelAttachment());
+      // cube->setLabelsExternal(att.labelAttachment() == ExternalLabel);
       if(att.propagatePixelType()) {
         if(InputCubes.size() > 0) {
           cube->setPixelType(InputCubes[0]->pixelType());

--- a/isis/src/base/objs/imageIoHandler/GdalIoHandler.cpp
+++ b/isis/src/base/objs/imageIoHandler/GdalIoHandler.cpp
@@ -20,6 +20,9 @@ namespace Isis {
     std::string dataFilePathStr = dataFilePath.toUtf8().constData();
     const char *charDataFilePath = dataFilePathStr.c_str();
     m_geodataSet = GDALDatasetUniquePtr(GDALDataset::FromHandle(GDALOpen(charDataFilePath, eAccess)));
+    std::cout << m_geodataSet->GetRasterXSize() << std::endl;
+    std::cout << m_geodataSet->GetRasterYSize() << std::endl;
+    std::cout << m_geodataSet->GetRasterCount() << std::endl;
     if (!m_geodataSet) {
       QString msg = "Constructing GdalIoHandler failed";
       throw IException(IException::Programmer, msg, _FILEINFO_);

--- a/isis/src/lro/apps/lronac2isis/lronac2isis.cpp
+++ b/isis/src/lro/apps/lronac2isis/lronac2isis.cpp
@@ -107,7 +107,7 @@ namespace Isis {
     g_ocube->setByteOrder(outAtt.byteOrder());
     g_ocube->setFormat(outAtt.fileFormat());
     g_ocube->setMinMax((double) VALID_MIN2, (double) VALID_MAX2);
-    g_ocube->setLabelsAttached(outAtt.labelAttachment() == AttachedLabel);
+    g_ocube->setLabelsAttached(outAtt.labelAttachment());
     g_ocube->setDimensions(p.Samples(), p.Lines(), p.Bands());
     g_ocube->setPixelType(Isis::Real);
     g_ocube->create(ui.GetCubeName("TO"));

--- a/isis/src/mex/apps/hrsc2isis/hrsc2isis.cpp
+++ b/isis/src/mex/apps/hrsc2isis/hrsc2isis.cpp
@@ -151,7 +151,7 @@ namespace Isis{
 
     outCube->setByteOrder(outAtt.byteOrder());
     outCube->setFormat(outAtt.fileFormat());
-    outCube->setLabelsAttached(outAtt.labelAttachment() == AttachedLabel);
+    outCube->setLabelsAttached(outAtt.labelAttachment());
 
     TableField ephTimeField("EphemerisTime", TableField::Double);
     TableField expTimeField("ExposureTime", TableField::Double);

--- a/isis/src/mro/apps/marcical/marcical.cpp
+++ b/isis/src/mro/apps/marcical/marcical.cpp
@@ -297,7 +297,7 @@ namespace Isis {
     ocube.setDimensions(icube.sampleCount(), icube.lineCount(), icube.bandCount());
     ocube.setByteOrder(outAtt.byteOrder());
     ocube.setFormat(outAtt.fileFormat());
-    ocube.setLabelsAttached(outAtt.labelAttachment() == AttachedLabel);
+    ocube.setLabelsAttached(outAtt.labelAttachment());
     ocube.setPixelType(outAtt.pixelType());
 
     ocube.create(FileName(ui.GetCubeName("TO")).expanded());

--- a/isis/src/odyssey/apps/thmvisflat/main.cpp
+++ b/isis/src/odyssey/apps/thmvisflat/main.cpp
@@ -68,7 +68,7 @@ void IsisMain() {
   ocube.setDimensions(icube.sampleCount(), icube.lineCount(), icube.bandCount());
   ocube.setByteOrder(outAtt.byteOrder());
   ocube.setFormat(outAtt.fileFormat());
-  ocube.setLabelsAttached(outAtt.labelAttachment() == AttachedLabel);
+  ocube.setLabelsAttached(outAtt.labelAttachment());
   ocube.setPixelType(outAtt.pixelType());
 
   ocube.create(FileName(ui.GetCubeName("TO")).expanded());

--- a/isis/src/qisis/objs/FileTool/FileTool.cpp
+++ b/isis/src/qisis/objs/FileTool/FileTool.cpp
@@ -559,7 +559,7 @@ namespace Isis {
       ocube->setDimensions(piNumSamples, piNumLines, piNumBands);
       ocube->setByteOrder(outAtt.byteOrder());
       ocube->setFormat(outAtt.fileFormat());
-      ocube->setLabelsAttached(outAtt.labelAttachment() == AttachedLabel);
+      ocube->setLabelsAttached(outAtt.labelAttachment());
 
       if (outAtt.propagatePixelType()) {
         ocube->setPixelType(icube->pixelType());

--- a/isis/src/qisis/objs/Image/Image.cpp
+++ b/isis/src/qisis/objs/Image/Image.cpp
@@ -550,7 +550,7 @@ namespace Isis {
 
         // If this is an ecub (it should be) and is pointing to a relative file name,
         //   then we want to copy the DN cube also.
-        if (!origImage.storesDnData() ) {
+        if ( origImage.labelsAttached() == Cube::ExternalLabel) {
           if (origImage.externalCubeFileName().path() == ".") {
             Cube dnFile(
                 FileName(m_fileName).path() + "/" + origImage.externalCubeFileName().name());

--- a/isis/src/qisis/objs/Shape/Shape.cpp
+++ b/isis/src/qisis/objs/Shape/Shape.cpp
@@ -564,7 +564,7 @@ namespace Isis {
 
       // If this is an ecub (it should be) and is pointing to a relative file name,
       //   then we want to copy the DN cube also.
-      if (!origShape.storesDnData()) {
+      if ( origShape.labelsAttached() == Cube::ExternalLabel ) {
         if (origShape.externalCubeFileName().path() == ".") {
           Cube dnFile(
               FileName(m_fileName).path() + "/" + origShape.externalCubeFileName().name());

--- a/isis/tests/FunctionalTestsCubeatt.cpp
+++ b/isis/tests/FunctionalTestsCubeatt.cpp
@@ -46,7 +46,7 @@ TEST_F(SmallCube, FunctionalTestCubeattNoChange) {
   // Check attributes: pixel type, storage format, label format, storage order, pixel range, bands
   EXPECT_EQ(outputCube.pixelType(), PixelType::Real);
   EXPECT_EQ(outputCube.format(), Cube::Format::Tile);
-  EXPECT_TRUE(outputCube.labelsAttached());
+  EXPECT_EQ(outputCube.labelsAttached(), Cube::AttachedLabel);
   EXPECT_EQ(outputCube.byteOrder(), ByteOrder::Lsb);
   // Setting the pixel range modifies the base/multiplier, so check those.
   EXPECT_EQ(outputCube.base(), 0);


### PR DESCRIPTION
## Description
Makes the current state of the ISIS label more explicit by reducing the number of flags that define the state under a single variable that explicitly uses the `CubeAttribute` enum for label state

## Related Issue
ISIS I/O

## How Has This Been Validated?
<!--- All changes need to be validated to confirm that they produce -->
<!--- scientifically accurate results. -->
<!--- If your changes include any new algorithms or changes to existing algorithms, -->
<!--- please indicate any publications or references for them. -->
<!--- If you manually validated the changes please indicate -->
<!--- what data you used and how you checked the results. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [ ] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [ ] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [ ] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
