### PR TITLE
added virtual band checks

### DIFF
--- a/isis/src/base/objs/ImageIoHandler/GdalIoHandler.cpp
+++ b/isis/src/base/objs/ImageIoHandler/GdalIoHandler.cpp
@@ -40,8 +40,11 @@ namespace Isis {
   void GdalIoHandler::read(Buffer &bufferToFill) const {
     GDALRasterBand  *poBand;
     int band = bufferToFill.Band();
-    // Check bands and apply virtual bands
+
+    if (m_virtualBands)
+      band = m_virtualBands->at(band - 1);
     poBand = m_geodataSet->GetRasterBand(band);
+    
     // Account for 1 based line and sample reading from ISIS process classes
     // as gdal reads 0 based lines and samples
     int lineStart = bufferToFill.Line() - 1;
@@ -78,7 +81,11 @@ namespace Isis {
 
   void GdalIoHandler::write(const Buffer &bufferToWrite) {
     GDALRasterBand  *poBand;
+    
     int band = bufferToWrite.Band();
+    if(m_virtualBands) 
+      band = m_virtualBands->indexOf(band) + 1;
+
     poBand = m_geodataSet->GetRasterBand(band);
 
     int lineStart = bufferToWrite.Line() - 1;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail including motivation and any context -->

I think this is all that's needed to use virt bands. 

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Validated?
<!--- All changes need to be validated to confirm that they produce -->
<!--- scientifically accurate results. -->
<!--- If your changes include any new algorithms or changes to existing algorithms, -->
<!--- please indicate any publications or references for them. -->
<!--- If you manually validated the changes please indicate -->
<!--- what data you used and how you checked the results. -->

used cubeatt on two THEMIS cubes, a standard cube using the lastest RC and a gdal ecub, extracting band 3 and ran cubediff on them both and it returned identical 

```
  (isis) igswza281l2305:cubes krodriguez$ cubediff from=/tmp/test1.cub from2=/tmp/test2.cub 
  Group = Results
    Compare = Identical
  End_Group 
```


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [ ] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [ ] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [ ] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
